### PR TITLE
test: PostByIdPage에서 + 클릭시 PostPage로 넘어갈때 url path 수정

### DIFF
--- a/src/pages/PostByIdPage.jsx
+++ b/src/pages/PostByIdPage.jsx
@@ -11,6 +11,7 @@ import { changeBgColor } from "../post-by-id/ChangeBgColor";
 
 export const PostByIdPage = () => {
   const { recipientId } = useParams();
+  const pathToPost = `/post/${recipientId}/message`;
 
   const [posts, setPosts] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,7 +48,7 @@ export const PostByIdPage = () => {
         />
       )}
       <CardByIdList>
-        <Link to="/post/:recipientId/message">
+        <Link to={pathToPost}>
           <CardButton />
         </Link>
         {posts?.map((post) => (


### PR DESCRIPTION
PostByIdPage에서 CardButton (+) 클릭시 PostPage로 넘어갈때 path에 id가 제대로 안넘어갔던 것을 수정하였습니다.

수정전 : /post/:recipientId/message/ 
수정후: /post/1427/message